### PR TITLE
Fixed semicolon shown in ManageOrganization view

### DIFF
--- a/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
+++ b/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
@@ -122,7 +122,7 @@
             ProfileUrlTemplate = Url.UserTemplate().LinkTemplate
         }));
     </script>
-    @ViewHelpers.SectionsScript(this);
+    @ViewHelpers.SectionsScript(this)
     @Scripts.Render("~/Scripts/gallery/page-manage-organization.min.js")
     @if (Model.IsCertificatesUIEnabled)
     {


### PR DESCRIPTION
If you visit any organization management page like https://www.nuget.org/organization/_YourOrganziation_ it will print a semicolon on the end of the page.